### PR TITLE
time series

### DIFF
--- a/myshop/shop/result_functions.py
+++ b/myshop/shop/result_functions.py
@@ -5,6 +5,7 @@ import mpld3
 import seaborn as sns
 import numpy as np
 import pandas as pd
+import datetime
 from sklearn.linear_model import LogisticRegression, LinearRegression, Lasso, Ridge
 from sklearn.cross_validation import train_test_split
 from sklearn.metrics import roc_curve, auc, roc_auc_score, r2_score
@@ -123,4 +124,19 @@ class result_function(object):
             fig_html = mpld3.fig_to_html(fig)
         else:
             fig_html = "Error: No y variable was provided."           
+        return fig_html
+    def timeseries(self, dataview_df, date_columns, input_columns, output_variable):
+        ip_input2 = pd.DataFrame(dataview_df)
+        ip_input = ip_input2.loc[ip_input2['BEN_ID'] == dataview_df[[input_columns]]]
+        ip_input = pd.DataFrame(dataview_df[[input_columns]])
+        ip_input[output_variable] = pd.to_numeric(dataview_df[[output_variable]])
+        ip_input['date'] = dataview_df[[date_columns]]
+        ip_input = ip_input2.sort_values(by='date', kind = 'mergesort')
+        ip_input['date'] = pd.to_datetime(dataview_df[[date_columns]], format='%Y%m%d')
+        x = ip_input['date']
+        y = ip_input[output_variable]
+        fig, ax = plt.subplots()
+        ax.set_title(output_variable + 'Time Series')
+        ax.plot(x,y, linestyle = 'None', marker = '8')
+        fig_html = mpld3.fig_to_html(fig)
         return fig_html


### PR DESCRIPTION
- date_columns is the column for the claim admission date
- input_columns are the selected beneficiary ID rows from the dataframe
- output_variable is either the claim admission date or the day count 

I can't figure out a way to differentiate the beneficiary ID output variables as to display them differently by color. 

The only way that I can think to do this would be to use a loop since you have to adjust the plotting contingent on each BEN_ID. However, I know you're not a fan of loops so I avoided that. 

At the very least they'll be able to plot the claim day counts and claim payment amounts for each beneficiary ID or a combination of multiple IDs. It would be helpful to have color differentiation for up to 6-8 IDs before it becomes rather indistinguishable. I don't see it as a large issue as long as you can plot multiple IDs. Once we figure out how to select multiple IDs through the dropdown, I may be able to come up with some color differentiation device through matplotlib or another resource.